### PR TITLE
zha support for ICTCG1Controller

### DIFF
--- a/apps/controllerx/core/type/light_controller.py
+++ b/apps/controllerx/core/type/light_controller.py
@@ -251,10 +251,11 @@ class LightController(ReleaseHoldController):
 
     @action
     async def on_full(self, attribute):
+        await self.on()
         attribute = await self.get_attribute(attribute)
         stepper = self.manual_steppers[attribute]
         await self.change_light_state(
-            stepper.minmax.min, attribute, Stepper.UP, stepper,
+            stepper.minmax.max, attribute, Stepper.UP, stepper,
         )
 
     async def get_attribute(self, attribute):

--- a/apps/controllerx/devices/ikea.py
+++ b/apps/controllerx/devices/ikea.py
@@ -178,10 +178,10 @@ class ICTCG1Controller(LightController):
         return {
             "move_1_70": Light.HOLD_BRIGHTNESS_DOWN,
             "move_1_195": Light.HOLD_BRIGHTNESS_DOWN,
-            "move_to_level_with_on_off_0_1": Light.OFF,
+            "move_to_level_with_on_off_0_1": "rotate_left_quick",
             "move_with_on_off_0_70": Light.HOLD_BRIGHTNESS_UP,
-            "move_with_on_off_0_195": Light.HOLD_BRIGHTNESS_UP,
-            "move_to_level_with_on_off_255_1": Light.ON_FULL_BRIGHTNESS,
+            "move_with_on_off_0_195": Light.ON,
+            "move_to_level_with_on_off_255_1": "rotate_right_quick",
             "stop": Light.RELEASE,
         }
 

--- a/apps/controllerx/devices/ikea.py
+++ b/apps/controllerx/devices/ikea.py
@@ -174,6 +174,17 @@ class ICTCG1Controller(LightController):
             "rotate_stop": Light.RELEASE,
         }
 
+    def get_zha_actions_mapping(self):
+        return {
+            "move_1_70": Light.HOLD_BRIGHTNESS_DOWN,
+            "move_1_195": Light.HOLD_BRIGHTNESS_DOWN,
+            "move_to_level_with_on_off_0_1": Light.OFF,
+            "move_with_on_off_0_70": Light.HOLD_BRIGHTNESS_UP,
+            "move_with_on_off_0_195": Light.HOLD_BRIGHTNESS_UP,
+            "move_to_level_with_on_off_255_1": Light.ON_FULL_BRIGHTNESS,
+            "stop": Light.RELEASE,
+        }
+
 
 class E1744LightController(LightController):
     # Different states reported from the controller:

--- a/tests/core/type/light_controller_test.py
+++ b/tests/core/type/light_controller_test.py
@@ -200,13 +200,13 @@ async def test_toggle(sut, mocker):
 @pytest.mark.asyncio
 async def test_on_full(sut, mocker):
     attribute = "test_attribute"
-    min_ = 1
+    max_ = 10
     change_light_state_patch = mocker.patch.object(sut, "change_light_state")
-    stepper = MinMaxStepper(min_, 10, 10)
+    stepper = MinMaxStepper(1, max_, 10)
     sut.manual_steppers = {attribute: stepper}
     await sut.on_full(attribute)
     change_light_state_patch.assert_called_once_with(
-        min_, attribute, Stepper.UP, stepper
+        max_, attribute, Stepper.UP, stepper
     )
 
 


### PR DESCRIPTION
This adds zha support for the ICTC-G-1 controller.
The device is VERY chatty with zha_event so the sometimes the behaviour is a little wonky. The dimmer I tested with isn't the latest firmware so I will try and update it and see if that makes any difference.
Note that I used Light.HOLD_BRIGHTNESS_DOWN and Light.HOLD_BRIGHTNESS_UP twice as there are two different args, depending on the rate at which you rotate the dimmer - slow or fast. This is still separate from "quick" right and left. I tried with no args (just "move" and "move_with_on_off" but then I got no dimming at all with rotation - maybe an issue with args processing?