### PR TITLE
Support SmartThings/Samjin Button

### DIFF
--- a/apps/controllerx/controllerx.py
+++ b/apps/controllerx/controllerx.py
@@ -10,3 +10,4 @@ from core import CustomMediaPlayerController
 from devices.aqara import *
 from devices.ikea import *
 from devices.philips import *
+from devices.samjin import *

--- a/apps/controllerx/core/integration/zha.py
+++ b/apps/controllerx/core/integration/zha.py
@@ -16,7 +16,7 @@ class ZHAIntegration(Integration):
     async def callback(self, event_name, data, kwargs):
         action = data["command"]
         args = list(map(str, data["args"]))
-        if not (action == "stop" or action == "release"):
+        if not (action == "stop" or action == "release" or action == "button_single" or action == "button_double" or action == "button_hold"):
             if len(args) > 0:
                 action += "_" + "_".join(args)
         await self.controller.handle_action(action)

--- a/apps/controllerx/devices/samjin.py
+++ b/apps/controllerx/devices/samjin.py
@@ -28,7 +28,7 @@ class SamjinButtonController(LightController):
             "button_hold": Light.SET_HALF_BRIGHTNESS,
         }
 
-    class SamjinButtonMediaPlayerController(MediaPlayerController):
+class SamjinButtonMediaPlayerController(MediaPlayerController):
     """
     This controller sends click, double click, and hold commands.
     No release command is sent.

--- a/apps/controllerx/devices/samjin.py
+++ b/apps/controllerx/devices/samjin.py
@@ -3,15 +3,16 @@ from const import Light
 
 class SamjinButton(LightController):
     """
-    This controller allows press, double press, and hold.
+    This controller allows click, double click, and hold.
+    No release command is sent.
     """
 
     # Different states reported from the controller:
-    # press, double press, hold
+    # button_single, button_double, button_hold
 
     def get_zha_actions_mapping(self):
         return {
-            "press": Light.TOGGLE,
-            "double_press": Light.ON_FULL_BRIGHTNESS,
-            "long_press": Light.HOLD_BRIGHTNESS_TOGGLE,
+            "button_single": Light.TOGGLE,
+            "button_double": Light.ON_FULL_BRIGHTNESS,
+            "button_hold": Light.SET_HALF_BRIGHTNESS,
         }

--- a/apps/controllerx/devices/samjin.py
+++ b/apps/controllerx/devices/samjin.py
@@ -1,0 +1,17 @@
+from core import LightController, Stepper
+from const import Light
+
+class SamjinButton(LightController):
+    """
+    This controller allows press, double press, and hold.
+    """
+
+    # Different states reported from the controller:
+    # press, double press, hold
+
+    def get_zha_actions_mapping(self):
+        return {
+            "press": Light.TOGGLE,
+            "double_press": Light.ON_FULL_BRIGHTNESS,
+            "long_press": Light.HOLD_BRIGHTNESS_TOGGLE,
+        }

--- a/apps/controllerx/devices/samjin.py
+++ b/apps/controllerx/devices/samjin.py
@@ -1,18 +1,56 @@
-from core import LightController, Stepper
-from const import Light
+from core import LightController, MediaPlayerController
+from const import Light, MediaPlayer
 
-class SamjinButton(LightController):
+class SamjinButtonController(LightController):
     """
-    This controller allows click, double click, and hold.
+    This controller sends click, double click, and hold commands.
     No release command is sent.
     """
-
-    # Different states reported from the controller:
-    # button_single, button_double, button_hold
-
+    
+    def get_z2m_actions_mapping(self):
+        return {
+            "single_click": Light.TOGGLE,
+            "double_click": Light.ON_FULL_BRIGHTNESS,
+            "hold": Light.SET_HALF_BRIGHTNESS,
+        }
+    
+    def get_deconz_actions_mapping(self):
+        return {
+            1002: Light.TOGGLE,
+            1004: Light.ON_FULL_BRIGHTNESS,
+            1001: Light.SET_HALF_BRIGHTNESS,
+        }
+    
     def get_zha_actions_mapping(self):
         return {
             "button_single": Light.TOGGLE,
             "button_double": Light.ON_FULL_BRIGHTNESS,
             "button_hold": Light.SET_HALF_BRIGHTNESS,
+        }
+
+    class SamjinButtonMediaPlayerController(MediaPlayerController):
+    """
+    This controller sends click, double click, and hold commands.
+    No release command is sent.
+    """
+    
+    def get_z2m_actions_mapping(self):
+        return {
+            "single_click": MediaPlayer.PLAY_PAUSE,
+            "double_click": MediaPlayer.NEXT_TRACK,
+            "hold": MediaPlayer.PREVIOUS_TRACK,
+        }
+    
+    def get_deconz_actions_mapping(self):
+        return {
+            1002: MediaPlayer.PLAY_PAUSE,
+            1004: MediaPlayer.NEXT_TRACK,
+            1001: MediaPlayer.PREVIOUS_TRACK,
+        }
+    
+    def get_zha_actions_mapping(self):
+        return {
+            "button_single": MediaPlayer.PLAY_PAUSE,
+            "button_double": MediaPlayer.NEXT_TRACK,
+            "button_hold": MediaPlayer.PREVIOUS_TRACK,
         }


### PR DESCRIPTION
This adds support for z2m, zha and deconz for the Samjin Button.
[https://www.samsung.com/ca/smart-things/button/](url)
Had to work around zha processing of the args which needs to be fixed prior to implementation - filed and issue (#33) to explore other options. 