### PR TITLE
Lutron support

### DIFF
--- a/apps/controllerx/controllerx.py
+++ b/apps/controllerx/controllerx.py
@@ -9,5 +9,6 @@ from core import CustomLightController
 from core import CustomMediaPlayerController
 from devices.aqara import *
 from devices.ikea import *
+from devices.lutron import *
 from devices.philips import *
 from devices.smartthings import *

--- a/apps/controllerx/devices/lutron.py
+++ b/apps/controllerx/devices/lutron.py
@@ -1,0 +1,67 @@
+from core import LightController, MediaPlayerController
+from const import Light, MediaPlayer
+
+
+class LutronCasetaProPicoLightController(LightController):
+    # This requires the LutronCasetaPro CUSTOM integration by upsert
+    # https://github.com/upsert/lutron-caseta-pro
+    # THIS WILL NOT WORK with the default Lutron Caseta integration
+    # Pico remotes using this integration report 6 states from their sensor:
+    # top button = "1", up button = "8", middle round = "2", down arrow = "16",
+    # bottom button = "4", no button pressed = "0"
+    # Sensor states are similar to z2m so can use that integration 
+    # and use "0" as release
+
+    def get_z2m_actions_mapping(self):
+        return {
+            "1": Light.ON_FULL_BRIGHTNESS,
+            "8": Light.HOLD_BRIGHTNESS_UP,
+            "2": Light.SET_HALF_BRIGHTNESS,
+            "16": Light.HOLD_BRIGHTNESS_DOWN,
+            "4": Light.OFF,
+            "0": Light.RELEASE,
+        }
+
+class LutronCasetaProPicoMediaPlayerController(MediaPlayerController):
+    # This requires the LutronCasetaPro CUSTOM integration by upsert
+    # https://github.com/upsert/lutron-caseta-pro
+    # THIS WILL NOT WORK with the default Lutron Caseta integration
+    # Pico remotes using this integration report 6 states from their sensor:
+    # top button = "1", up button = "8", middle round = "2", down arrow = "16",
+    # bottom button = "4", no button pressed = "0"
+    # Sensor states are similar to z2m so can use that integration 
+    # and use "0" as release
+
+    def get_z2m_actions_mapping(self):
+        return {
+            "1": MediaPlayer.PLAY_PAUSE,
+            "8": MediaPlayer.HOLD_VOLUME_UP,
+            "2": MediaPlayer.NEXT_SOURCE,
+            "16": MediaPlayer.HOLD_VOLUME_DOWN,
+            "4": MediaPlayer.NEXT_TRACK,
+            "0": MediaPlayer.RELEASE,
+        }
+
+class LZL4BWHL01Controller(LightController):
+    # Each button press fires an event but no separate 
+    # hold event. Press of up or down generates a stop event
+    # when released.
+
+    def get_zha_actions_mapping(self):
+        return {
+            "move_to_level_with_on_off_254_4": Light.ON_FULL_BRIGHTNESS,
+            "step_with_on_off_0_30_6": Light.HOLD_BRIGHTNESS_UP,
+            "step_1_30_6": Light.HOLD_BRIGHTNESS_DOWN,
+            "move_to_level_with_on_off_0_4": Light.OFF,
+            "stop": Light.RELEASE,
+        }
+        
+    def get_deconz_actions_mapping(self):
+        return {
+            1002: Light.ON_FULL_BRIGHTNESS,
+            2001: Light.HOLD_BRIGHTNESS_UP,
+            2003: Light.RELEASE,
+            3001: Light.HOLD_BRIGHTNESS_DOWN,
+            3003: Light.RELEASE,
+            4002: Light.OFF,
+        }


### PR DESCRIPTION
This adds both media player and light controller support for lutron pico remotes for those of us using the lutron-caseta-pro integration by upsert - https://github.com/upsert/lutron-caseta-pro

Also adds zha and deconz support for the connected bulb remote (LZL-4B-WH-L01) while I was at it :-)

Addresses #38 