### PR TITLE
Add ZHA support for HueDimmerController

### DIFF
--- a/apps/controllerx/devices/philips.py
+++ b/apps/controllerx/devices/philips.py
@@ -40,6 +40,16 @@ class HueDimmerController(LightController):
             4003: Light.RELEASE,
         }
 
+    def get_zha_actions_mapping(self) -> TypeActionsMapping:
+        return {
+            "on": Light.ON,
+            "step_0_30_9": Light.CLICK_BRIGHTNESS_UP,
+            "step_0_56_9": Light.HOLD_BRIGHTNESS_UP,
+            "step_1_30_9": Light.CLICK_BRIGHTNESS_DOWN,
+            "step_1_56_9": Light.HOLD_BRIGHTNESS_DOWN,
+            "off_with_effect_0_0": Light.OFF,
+            "stop": Light.RELEASE,
+        }
 
 class Niko91004LightController(LightController):
     def get_deconz_actions_mapping(self) -> TypeActionsMapping:

--- a/apps/controllerx/devices/philips.py
+++ b/apps/controllerx/devices/philips.py
@@ -51,6 +51,7 @@ class HueDimmerController(LightController):
             "stop": Light.RELEASE,
         }
 
+
 class Niko91004LightController(LightController):
     def get_deconz_actions_mapping(self) -> TypeActionsMapping:
         return {

--- a/docs/_data/controllers/hue-dimmer-switch.yml
+++ b/docs/_data/controllers/hue-dimmer-switch.yml
@@ -48,3 +48,16 @@ integrations:
       - "4001 🠖 Hold \"O\""
       - "4002 🠖 Click release \"O\""
       - "4003 🠖 Hold release \"O\""
+  - name: ZHA
+    codename: zha
+    actions:
+      - "on 🠖 Click \"I\""
+      - "step_0_30_9 🠖 Click 🔆"
+      - "step_0_56_9 🠖 Hold 🔆"
+      - "step_1_30_9 🠖 Click 🔅"
+      - "step_1_56_9 🠖 Hold 🔅"
+      - "off_with_effect_0_0 🠖 Click \"O\""
+      - "stop 🠖 Release brightness buttons"
+note: >-
+  For ZHA integration, the hold events just work for the brightness buttons,
+  and they are fired right after the click events.


### PR DESCRIPTION
This adds (limited) support for using the HueDimmerController with ZHA.
At least for my dimmer, no hold-events for the on and off buttons were created, so I could not add those.