### PR TITLE
Add support for legrand simple wall switch

### DIFF
--- a/apps/controllerx/controllerx.py
+++ b/apps/controllerx/controllerx.py
@@ -15,3 +15,4 @@ from cx_devices.lutron import *
 from cx_devices.philips import *
 from cx_devices.smartthings import *
 from cx_devices.trust import *
+from cx_devices.legrand import *

--- a/apps/controllerx/cx_core/controller.py
+++ b/apps/controllerx/cx_core/controller.py
@@ -215,7 +215,7 @@ class Controller(Hass, Mqtt, abc.ABC):
         """
         return None
 
-    def get_zha_action(self, command: str, args) -> Optional[str]:
+    def get_zha_action(self, data: dict) -> Optional[str]:
         """
         This method can be override for controllers that do not support
         the standard extraction of the actions on cx_core/integration/zha.py

--- a/apps/controllerx/cx_core/integration/zha.py
+++ b/apps/controllerx/cx_core/integration/zha.py
@@ -18,7 +18,9 @@ class ZHAIntegration(Integration):
             self.controller, self.callback, "zha_event", device_ieee=controller_id
         )
 
-    def get_action(self, command: str, args):
+    def get_action(self, data: dict):
+        command = data["command"]
+        args = data["args"]
         if isinstance(args, dict):
             args = args["args"]
         args = list(map(str, args))
@@ -29,11 +31,9 @@ class ZHAIntegration(Integration):
         return action
 
     async def callback(self, event_name: str, data: dict, kwargs: dict) -> None:
-        command = data["command"]
-        args = data["args"]
-        action = self.controller.get_zha_action(command, args)
+        action = self.controller.get_zha_action(data)
         if action is None:
             # If there is no action extracted from the controller then
             # we extract with the standard function
-            action = self.get_action(command, args)
+            action = self.get_action(data)
         await self.controller.handle_action(action)

--- a/apps/controllerx/cx_devices/aqara.py
+++ b/apps/controllerx/cx_devices/aqara.py
@@ -53,8 +53,8 @@ class WXKG01LMLightController(LightController):
             "quadruple": Light.SET_HALF_BRIGHTNESS,
         }
 
-    def get_zha_action(self, command: str, args) -> str:
-        return args["click_type"]
+    def get_zha_action(self, data: dict) -> str:
+        return data["args"]["click_type"]
 
 
 class WXKG11LMLightController(LightController):
@@ -150,8 +150,9 @@ class MFKZQ01LMLightController(LightController):
             "rotate_right": Light.CLICK_BRIGHTNESS_UP,
         }
 
-    def get_zha_action(self, command: str, args) -> str:
-        action = command
+    def get_zha_action(self, data: dict) -> str:
+        command = action = data["command"]
+        args = data.get("args", {})
         if command == "flip":
             action = command + str(args["flip_degrees"])
         return action

--- a/apps/controllerx/cx_devices/legrand.py
+++ b/apps/controllerx/cx_devices/legrand.py
@@ -1,0 +1,16 @@
+from cx_const import Light, TypeActionsMapping
+from cx_core import LightController
+
+
+class SimpleWallSwitchController(LightController):
+    # Different states reported from the controller:
+    # on, off, brightness_up, brightness_down, brightness_stop
+
+    def get_zha_actions_mapping(self) -> TypeActionsMapping:
+        return {
+            "on": Light.ON,
+            "off": Light.OFF,
+            "move_0_255": Light.HOLD_BRIGHTNESS_UP,
+            "move_1_255": Light.HOLD_BRIGHTNESS_DOWN,
+            "stop": Light.RELEASE,
+        }

--- a/apps/controllerx/cx_devices/legrand.py
+++ b/apps/controllerx/cx_devices/legrand.py
@@ -1,16 +1,49 @@
+from typing import Optional
+
 from cx_const import Light, TypeActionsMapping
 from cx_core import LightController
 
 
-class SimpleWallSwitchController(LightController):
-    # Different states reported from the controller:
-    # on, off, brightness_up, brightness_down, brightness_stop
+def get_zha_action_LegrandWallController(data: dict) -> Optional[str]:
+    endpoint_id = data.get("endpoint_id", 1)
+    command = action = data["command"]
+    args = data.get("args", {})
+    args_mapping = {0: "up", 1: "down"}
+    if command == "move":
+        action = "_".join((action, args_mapping[args[0]]))
+    action = "_".join((str(endpoint_id), action))
+    return action
 
+
+class LegrandSimpleWallLightController(LightController):
     def get_zha_actions_mapping(self) -> TypeActionsMapping:
         return {
-            "on": Light.ON,
-            "off": Light.OFF,
-            "move_0_255": Light.HOLD_BRIGHTNESS_UP,
-            "move_1_255": Light.HOLD_BRIGHTNESS_DOWN,
-            "stop": Light.RELEASE,
+            "1_on": Light.ON,
+            "1_off": Light.OFF,
+            "1_move_up": Light.HOLD_BRIGHTNESS_UP,
+            "1_move_down": Light.HOLD_BRIGHTNESS_DOWN,
+            "1_stop": Light.RELEASE,
         }
+
+    def get_zha_action(self, data: dict) -> Optional[str]:
+        return get_zha_action_LegrandWallController(data)
+
+
+class LegrandDoubleWallLightController(LightController):
+    # TODO: define the mapping for this controller
+    def get_zha_actions_mapping(self) -> TypeActionsMapping:
+        return {
+            "1_on": Light.ON,
+            "1_off": Light.OFF,
+            "1_move_up": Light.HOLD_BRIGHTNESS_UP,
+            "1_move_down": Light.HOLD_BRIGHTNESS_DOWN,
+            "1_stop": Light.RELEASE,
+            "2_on": Light.ON,
+            "2_off": Light.OFF,
+            "2_move_up": Light.HOLD_BRIGHTNESS_UP,
+            "2_move_down": Light.HOLD_BRIGHTNESS_DOWN,
+            "2_stop": Light.RELEASE,
+        }
+
+    def get_zha_action(self, data: dict) -> Optional[str]:
+        return get_zha_action_LegrandWallController(data)

--- a/apps/controllerx/cx_devices/legrand.py
+++ b/apps/controllerx/cx_devices/legrand.py
@@ -15,7 +15,7 @@ def get_zha_action_LegrandWallController(data: dict) -> Optional[str]:
     return action
 
 
-class LegrandSimpleWallLightController(LightController):
+class Legrand600083LightController(LightController):
     def get_zha_actions_mapping(self) -> TypeActionsMapping:
         return {
             "1_on": Light.ON,
@@ -29,17 +29,16 @@ class LegrandSimpleWallLightController(LightController):
         return get_zha_action_LegrandWallController(data)
 
 
-class LegrandDoubleWallLightController(LightController):
-    # TODO: define the mapping for this controller
+class Legrand600088LightController(LightController):
     def get_zha_actions_mapping(self) -> TypeActionsMapping:
         return {
             "1_on": Light.ON,
             "1_off": Light.OFF,
-            "1_move_up": Light.HOLD_BRIGHTNESS_UP,
-            "1_move_down": Light.HOLD_BRIGHTNESS_DOWN,
+            "1_move_up": Light.HOLD_COLOR_UP,
+            "1_move_down": Light.HOLD_COLOR_DOWN,
             "1_stop": Light.RELEASE,
-            "2_on": Light.ON,
-            "2_off": Light.OFF,
+            "2_on": Light.ON_FULL_BRIGHTNESS,
+            "2_off": Light.ON_MIN_BRIGHTNESS,
             "2_move_up": Light.HOLD_BRIGHTNESS_UP,
             "2_move_down": Light.HOLD_BRIGHTNESS_DOWN,
             "2_stop": Light.RELEASE,

--- a/docs/_data/controllers/LEGRAND-600083.yml
+++ b/docs/_data/controllers/LEGRAND-600083.yml
@@ -1,0 +1,20 @@
+name: 600083 (LEGRAND)
+device_support:
+  - type: Light
+    domain: light
+    controller: Legrand600083LightController
+    delay: 350
+    mapping:
+      - press top button 🠖 Turn on
+      - press bottom button 🠖 Turn off
+      - hold top button 🠖 Brighten up
+      - hold bottom button 🠖 Dim down
+integrations:
+  - name: ZHA
+    codename: zha
+    actions:
+      - 1_on 🠖 press top button
+      - 1_off 🠖 press bottom button
+      - 1_move_up 🠖 hold top button
+      - 1_move_down 🠖 hold bottom button
+      - 1_stop 🠖 release any button

--- a/docs/_data/controllers/LEGRAND-600088.yml
+++ b/docs/_data/controllers/LEGRAND-600088.yml
@@ -1,0 +1,29 @@
+name: 600088 (LEGRAND)
+device_support:
+  - type: Light
+    domain: light
+    controller: Legrand600088LightController
+    delay: 350
+    mapping:
+      - press left top button 🠖 Turn on
+      - press left bottom button 🠖 Turn off
+      - hold left top button 🠖 Change color or color temperature up
+      - hold left bottom button 🠖 Change color or color temperature down
+      - press right top button 🠖 Full brightness
+      - press right bottom button 🠖 Minimum brightness
+      - hold right top button 🠖 Brighten up
+      - hold right bottom button 🠖 Dim down
+integrations:
+  - name: ZHA
+    codename: zha
+    actions:
+      - 1_on 🠖 press left top button
+      - 1_off 🠖 press left bottom button
+      - 1_move_up 🠖 hold left top button
+      - 1_move_down 🠖 hold left bottom button
+      - 1_stop 🠖 release any left button
+      - 2_on 🠖 press right top button
+      - 2_off 🠖 press right bottom button
+      - 2_move_up 🠖 hold right top button
+      - 2_move_down 🠖 hold right bottom button
+      - 2_stop 🠖 release any right button

--- a/docs/controllers/LEGRAND-600083.md
+++ b/docs/controllers/LEGRAND-600083.md
@@ -1,0 +1,5 @@
+---
+layout: controller
+title: 600083 (LEGRAND)
+device: LEGRAND-600083
+---

--- a/docs/controllers/LEGRAND-600088.md
+++ b/docs/controllers/LEGRAND-600088.md
@@ -1,0 +1,5 @@
+---
+layout: controller
+title: 600088 (LEGRAND)
+device: LEGRAND-600088
+---

--- a/tests/cx_devices/aqara_test.py
+++ b/tests/cx_devices/aqara_test.py
@@ -3,34 +3,34 @@ from cx_devices.aqara import MFKZQ01LMLightController, WXKG01LMLightController
 
 
 @pytest.mark.parametrize(
-    "command, args, expected_action",
+    "data, expected_action",
     [
-        ("shake", {}, "shake"),
-        ("knock", {}, "knock"),
-        ("slide", {}, "slide"),
-        ("flip", {"flip_degrees": 90}, "flip90"),
-        ("flip", {"flip_degrees": 180}, "flip180"),
-        ("rotate_left", {}, "rotate_left"),
-        ("rotate_right", {}, "rotate_right"),
+        ({"command": "shake"}, "shake"),
+        ({"command": "knock"}, "knock"),
+        ({"command": "slide"}, "slide"),
+        ({"command": "flip", "args": {"flip_degrees": 90}}, "flip90",),
+        ({"command": "flip", "args": {"flip_degrees": 180}}, "flip180"),
+        ({"command": "rotate_left"}, "rotate_left"),
+        ({"command": "rotate_right"}, "rotate_right"),
     ],
 )
-def test_zha_action_MFKZQ01LMLightController(command, args, expected_action):
+def test_zha_action_MFKZQ01LMLightController(data, expected_action):
     sut = MFKZQ01LMLightController()
-    action = sut.get_zha_action(command, args)
+    action = sut.get_zha_action(data)
     assert action == expected_action
 
 
 @pytest.mark.parametrize(
-    "command, args, expected_action",
+    "data, expected_action",
     [
-        ("click", {"click_type": "single"}, "single"),
-        ("click", {"click_type": "double"}, "double"),
-        ("click", {"click_type": "triple"}, "triple"),
-        ("click", {"click_type": "quadruple"}, "quadruple"),
-        ("click", {"click_type": "furious"}, "furious"),
+        ({"command": "click", "args": {"click_type": "single"}}, "single"),
+        ({"command": "click", "args": {"click_type": "double"}}, "double"),
+        ({"command": "click", "args": {"click_type": "triple"}}, "triple"),
+        ({"command": "click", "args": {"click_type": "quadruple"}}, "quadruple"),
+        ({"command": "click", "args": {"click_type": "furious"}}, "furious"),
     ],
 )
-def test_zha_action_WXKG01LMLightController(command, args, expected_action):
+def test_zha_action_WXKG01LMLightController(data, expected_action):
     sut = WXKG01LMLightController()
-    action = sut.get_zha_action(command, args)
+    action = sut.get_zha_action(data)
     assert action == expected_action

--- a/tests/cx_devices/legrand_test.py
+++ b/tests/cx_devices/legrand_test.py
@@ -1,0 +1,21 @@
+import pytest
+
+from cx_devices.legrand import get_zha_action_LegrandWallController
+
+
+@pytest.mark.parametrize(
+    "data, expected_action",
+    [
+        ({"endpoint_id": 1, "command": "off", "args": []}, "1_off"),
+        ({"endpoint_id": 1, "command": "on", "args": []}, "1_on"),
+        ({"command": "off", "args": []}, "1_off"),
+        ({"command": "on", "args": []}, "1_on"),
+        ({"endpoint_id": 2, "command": "move", "args": [0, 255]}, "2_move_up"),
+        ({"endpoint_id": 2, "command": "move", "args": [1, 255]}, "2_move_down"),
+        ({"endpoint_id": 1, "command": "stop"}, "1_stop"),
+        ({"endpoint_id": 2, "command": "stop"}, "2_stop"),
+    ],
+)
+def test_get_zha_action_LegrandWallController(data, expected_action):
+    action = get_zha_action_LegrandWallController(data)
+    assert action == expected_action


### PR DESCRIPTION
This adds support for the Legrand [simple wall switch - 6 000 83](https://www.legrand.fr/pro/catalogue/42796-version-dooxie-with-netatmo/commande-sans-fil-dooxie-with-netatmo-pour-eclairage-ou-prise-connectee-ou-micromodule-blanc).

I originally posted this snippet in #98.