### PR TITLE
Fix KeyError in z2m integration

### DIFF
--- a/apps/controllerx/cx_core/integration/z2m.py
+++ b/apps/controllerx/cx_core/integration/z2m.py
@@ -40,7 +40,7 @@ class Z2MIntegration(Integration):
         if "payload" not in data:
             return
         payload = json.loads(data["payload"])
-        if action_key not in data["payload"]:
+        if action_key not in payload:
             self.controller.log(
                 f"⚠️ There is no `{action_key}` in the MQTT topic payload",
                 level="WARNING",

--- a/tests/cx_core/integration/z2m_test.py
+++ b/tests/cx_core/integration/z2m_test.py
@@ -11,6 +11,7 @@ from cx_core.integration.z2m import Z2MIntegration
         ({}, None, False, Any),
         ({"payload": '{"action": "action_1"}'}, None, True, "action_1"),
         ({"payload": '{"event_1": "action_1"}'}, "event_2", False, Any),
+        ({"payload": '{"action_rate": 195}'}, "action", False, Any),
     ],
 )
 @pytest.mark.asyncio


### PR DESCRIPTION
I've ran into the following error when using the Tradfri E1744 controller: 

```
Sep 16 17:11:26 flip appdaemon[26288]: 2020-09-16 17:11:26.828990 WARNING sound_controller_sideroom: ------------------------------------------------------------
Sep 16 17:11:26 flip appdaemon[26288]: 2020-09-16 17:11:26.829247 WARNING sound_controller_sideroom: Traceback (most recent call last):
Sep 16 17:11:26 flip appdaemon[26288]:   File "/home/homeassistant/appdaemon/lib/python3.7/site-packages/appdaemon/threading.py", line 838, in async_worker
Sep 16 17:11:26 flip appdaemon[26288]:     await funcref(args["event"], data, self.AD.events.sanitize_event_kwargs(app, args["kwargs"]))
Sep 16 17:11:26 flip appdaemon[26288]:   File "/home/homeassistant/homeassistant/appdaemon/apps/controllerx/cx_core/integration/z2m.py", line 50, in event_callback
Sep 16 17:11:26 flip appdaemon[26288]:     ascii_encode=False,
Sep 16 17:11:26 flip appdaemon[26288]: KeyError: 'action'
Sep 16 17:11:26 flip appdaemon[26288]: 2020-09-16 17:11:26.829399 WARNING sound_controller_sideroom: ------------------------------------------------------------
````

This is caused by the MQTT message containing the `action_rate` keyword that matches the action key in in the inparsed payload:
```
home/zigbee2mqtt/sound_controller_sideroom {"action_rate":195,"battery":60,"device":{"applicationVersion":33,"dateCode":"20190710","friendlyName":"sound_controller_sideroom",...}
```

By checking the parsed, payload for the action key the check should work and a warning is logged.