### PR TITLE
Add controller setting merge_mapping.

### DIFF
--- a/apps/controllerx/cx_core/controller.py
+++ b/apps/controllerx/cx_core/controller.py
@@ -64,6 +64,13 @@ class Controller(Hass, Mqtt, abc.ABC):
             }
         )
 
+        merge_mapping: Dict[Union[str, int], str] = self.args.get("merge_mapping", None)
+        if merge_mapping:
+            self.actions_key_mapping.update({
+                event: self.parse_action(action)
+                for event, action in merge_mapping.items()
+            })
+
         self.type_actions_mapping = self.get_type_actions_mapping()
         if "actions" in self.args and "excluded_actions" in self.args:
             raise ValueError("`actions` and `excluded_actions` cannot be used together")


### PR DESCRIPTION
This allows overriding only certain event-action mappings while keeping the default mappings for other events in place.

While the `mapping` setting completely replaces the default mapping, `merge_mapping` will keep the default actions for any events that are not explicitly redefined.

As this is currently untested and the implementation is still open for discussion, I did not yet include any documentation.

Resolves #135.