### PR TITLE
Add support for different group actions on ZYCT-202 on z2m(mqtt)

### DIFF
--- a/apps/controllerx/cx_core/integration/z2m.py
+++ b/apps/controllerx/cx_core/integration/z2m.py
@@ -38,6 +38,7 @@ class Z2MIntegration(Integration):
     async def event_callback(self, event_name: str, data: dict, kwargs: dict) -> None:
         self.controller.log(f"MQTT data event: {data}", level="DEBUG")
         action_key = self.kwargs.get("action_key", "action")
+        action_group_key = self.kwargs.get("action_group_key", "action_group")
         if "payload" not in data:
             return
         payload = json.loads(data["payload"])
@@ -48,6 +49,17 @@ class Z2MIntegration(Integration):
                 ascii_encode=False,
             )
             return
+        if action_group_key in payload and "action_group" in self.kwargs:
+            action_group = self.kwargs["action_group"]
+            if isinstance(action_group, str):
+                action_group = [action_group]
+            if payload["action_group"] not in action_group:
+                self.controller.log(
+                    f"Action group {payload['action_group']} not found in "
+                    f"action groups: {action_group}",
+                    level="DEBUG",
+                )
+                return
         await self.controller.handle_action(payload[action_key])
 
     async def state_callback(


### PR DESCRIPTION
Different actions can now be performed by different light groups. e.g. You can control both lights and music player.

Works only with `listen_to: mqtt` because we need more data than HASS integration provides (`listen_state` returns just target `on`/`off` state, while `listen_event` returns the entire `zigbee2mqtt`'s payload).

Example payload: `{"linkquality":36,"action":"off","action_group":146}`

Light groups are mapped as follows:
- light 1 - `145`
- light 2 - `146`
- light 3 - `147`
- light 4 - `148`
- light 5 - `149`
- all lights - `150`

Example from my `apps.yaml` configuration:
```
trust_remote_1:
  module: controllerx
  class: ZYCT202LightController
  controller: "Z2M NAME"
  integration:
    name: z2m
    listen_to: mqtt
    action_group:
      # I want `group 1` and `all groups` to work with this light
      - 145
      - 150
  light: light.LIGHT_NAME_1

trust_remote_2:
  module: controllerx
  class: ZYCT202LightController
  controller: "Z2M NAME"
  integration:
    name: z2m
    listen_to: mqtt
    action_group:
      # I want `group 2` and `all groups` to work with this light
      - 146
      - 150
  light: light.LIGHT_NAME_2
```