### PR TITLE
Add ZHA support for Ikea E1766 remote

### DIFF
--- a/apps/controllerx/cx_devices/ikea.py
+++ b/apps/controllerx/cx_devices/ikea.py
@@ -433,10 +433,19 @@ class E1766LightController(LightController):
             2003: Light.ON_MIN_BRIGHTNESS,
         }
 
+    def get_zha_actions_mapping(self) -> TypeActionsMapping:
+        return {
+            "up_open": Light.ON,
+            "down_close": Light.OFF,
+        }
+
 
 class E1766SwitchController(SwitchController):
     def get_deconz_actions_mapping(self) -> TypeActionsMapping:
         return {1002: Switch.ON, 2002: Switch.OFF}
+
+    def get_zha_actions_mapping(self) -> TypeActionsMapping:
+        return {"up_open": Switch.ON, "down_close": Switch.OFF}
 
 
 class E1766CoverController(CoverController):
@@ -444,4 +453,11 @@ class E1766CoverController(CoverController):
         return {
             1002: Cover.TOGGLE_OPEN,
             2002: Cover.TOGGLE_CLOSE,
+        }
+
+    def get_zha_actions_mapping(self) -> TypeActionsMapping:
+        return {
+            "up_open": Cover.TOGGLE_OPEN,
+            "down_close": Cover.TOGGLE_CLOSE,
+            "stop": Cover.STOP,
         }

--- a/docs/_data/controllers/E1766.yml
+++ b/docs/_data/controllers/E1766.yml
@@ -31,3 +31,9 @@ integrations:
       - "2002 → Click down"
       - "1003 → Hold up"
       - "2003 → Hold down"
+  - name: ZHA
+    codename: zha
+    actions:
+      - "up_open → Click up"
+      - "down_close → Click down"
+      - "stop → Release up or down" 


### PR DESCRIPTION
Holding the up and down fires the same event as a click up/down with a stop event on the release.