### PR TITLE
Fix a few typos in integrations.md

### DIFF
--- a/docs/docs/start/integrations.md
+++ b/docs/docs/start/integrations.md
@@ -10,9 +10,9 @@ Integrations is a way to abstract the logic from the event extraction in Control
 This integration(**`z2m`**) is meant to be used for zigbee2mqtt. It listens the states from the HA sensor entities. These are the accepted attributes:
 
 - `listen_to`: Indicates whether it listens for HA states (`ha`) or MQTT topics (`mqtt`). Default is `ha`.
-- `action_key`: It is the key inside the topic payload that contains the fired action from the controller. It is normally `action` or `click`. By default will be `action`. Only applicable is `listen_to` is `mqtt`.
-- `action_group` is a list of allowed action groups for the controller configuration. Read more about it [here](https://github.com/xaviml/controllerx/pull/150). Only applicable is `listen_to` is `mqtt`.
-- `topic_prefix`: MQTT base topic for Zigbee2MQTT MQTT messages. By default is `zigbee2mqtt`, and it listens to `<topic_prefix>/<controller_id>` for changes. Only applicable is `listen_to` is `mqtt`.
+- `action_key`: It is the key inside the topic payload that contains the fired action from the controller. It is normally `action` or `click`. By default will be `action`. Only applicable if `listen_to` is `mqtt`.
+- `action_group` is a list of allowed action groups for the controller configuration. Read more about it [here](https://github.com/xaviml/controllerx/pull/150). Only applicable if `listen_to` is `mqtt`.
+- `topic_prefix`: MQTT base topic for Zigbee2MQTT MQTT messages. By default is `zigbee2mqtt`, and it listens to `<topic_prefix>/<controller_id>` for changes. Only applicable if `listen_to` is `mqtt`.
 
 If you want to use the `mqtt`, then you will need to change the `appdaemon.yaml` as it is stated in the `MQTT` integration section. Imagine we have the following configuration already created for a `z2m` controller listening to HA state:
 


### PR DESCRIPTION
Changed instances of: "Only applicable is `listen_to` [...]"  to "Only applicable if `listen_to` [...]"