### PR TITLE
fix: temporary fix to template rendering

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -14,9 +14,9 @@ _This minor change does not contain any breaking changes._
 
 - [WXCJKG13LM](https://BASE_URL/controllerx/controllers/WXCJKG13LM) - add MediaPlayer controller with Z2M, deCONZ and ZHA support. [ #667 ] @mathieuric
 
-<!--
 ## :hammer: Fixes
--->
+
+- Temporarily fix issue with template rendering. Issue comes from AppDaemon [ #810 ]
 
 <!--
 ## :scroll: Docs

--- a/apps/controllerx/cx_core/controller.py
+++ b/apps/controllerx/cx_core/controller.py
@@ -33,6 +33,7 @@ from cx_const import (
     DefaultActionsMapping,
     PredefinedActionsMapping,
 )
+from cx_core import fix_template
 from cx_core import integration as integration_module
 from cx_core.action_type import ActionsMapping, parse_actions
 from cx_core.action_type.base import ActionType
@@ -360,6 +361,12 @@ class Controller(Hass, Mqtt):  # type: ignore[misc]
                 value = f"{value:.2f}"
             to_log.append(f"  - {attribute}: {value}")
         self.log("\n".join(to_log), level="INFO", ascii_encode=False)
+        # Start condition to be deleted
+        # Read doc string from apps/controllerx/cx_core/fix_template.py
+        if service == "template/render":
+            ha_config = self.config["plugins"]["HASS"]
+            return await fix_template.render_template(ha_config, attributes, self)
+        # End of condition to be deleted.
         return await ADAPI.call_service(self, service, **attributes)
 
     @utils.sync_wrapper  # type: ignore[misc]

--- a/apps/controllerx/cx_core/fix_template.py
+++ b/apps/controllerx/cx_core/fix_template.py
@@ -1,0 +1,84 @@
+"""
+This is a temporary module to fix AppDaemon 4.4.0 and 4.4.1 bug:
+
+https://github.com/AppDaemon/appdaemon/issues/1747
+
+It seems that the problem has been fixed (https://github.com/AppDaemon/appdaemon/pull/1750),
+but it is not known when the fix will be released.
+
+This module has a spcific function (similar to AppDaemon call) for template rendering.
+
+This entire file can be deleted once the fix is in place officially from AppDaemon.
+"""
+import asyncio
+import json
+import traceback
+from typing import TYPE_CHECKING, Any, Dict, Optional
+
+import aiohttp
+
+if TYPE_CHECKING:
+    from cx_core.controller import Controller
+
+
+def convert_json(data: Any, **kwargs: Any) -> str:
+    return json.dumps(data, default=str, **kwargs)
+
+
+domain = "template"
+service = "render"
+
+
+async def render_template(
+    config: Dict[str, Any], data: Any, controller: "Controller"
+) -> Optional[str]:
+    if isinstance(data, str):
+        data = {"entity_id": data}
+
+    if "token" in config:
+        headers = {"Authorization": "Bearer {}".format(config["token"])}
+    elif "ha_key" in config:
+        headers = {"x-ha-access": config["ha_key"]}
+    else:
+        headers = {}
+
+    api_url = "{}/api/template".format(config["ha_url"])
+
+    try:
+        async with aiohttp.ClientSession(
+            connector=aiohttp.TCPConnector(), json_serialize=convert_json
+        ) as session:
+            async with session.post(
+                api_url, headers=headers, json=data, verify_ssl=config["cert_verify"]
+            ) as resp:
+                if resp.status == 200 or resp.status == 201:
+                    result = await resp.text()
+                else:
+                    controller.log.warning(
+                        "Error calling Home Assistant service %s/%s",
+                        domain,
+                        service,
+                    )
+                    txt = await resp.text()
+                    controller.log.warning("Code: %s, error: %s", resp.status, txt)
+                    result = None
+
+                return result
+    except (asyncio.TimeoutError, asyncio.CancelledError):
+        controller.log(
+            "Timeout in call_service(%s/%s, %s)", domain, service, data, level="WARNING"
+        )
+    except aiohttp.client_exceptions.ServerDisconnectedError:
+        controller.log(
+            "HASS Disconnected unexpectedly during call_service()", level="WARNING"
+        )
+    except Exception:
+        controller.log("-" * 60, level="ERROR")
+        controller.log("Unexpected error during call_plugin_service()", level="ERROR")
+        controller.log(
+            "Service: %s.%s Arguments: %s", domain, service, data, level="ERROR"
+        )
+        controller.log("-" * 60, level="ERROR")
+        controller.log(traceback.format_exc(), level="ERROR")
+        controller.log("-" * 60, level="ERROR")
+    return None

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -80,6 +80,9 @@ exclude_lines = [
     # Logs can be ignored
     "self.log",
 ]
+omit = [
+    "apps/controllerx/cx_core/fix_template.py",
+]
 
 [tool.commitizen]
 name = "cz_conventional_commits"


### PR DESCRIPTION
This PR fixes an AppDaemon 4.4.0 and 4.4.1 bug:

https://github.com/AppDaemon/appdaemon/issues/1747

It seems that the problem has been fixed (https://github.com/AppDaemon/appdaemon/pull/1750),
but it is not known when the fix will be released.

This entire file can be deleted once the fix is in place officially from AppDaemon.