### PR TITLE
add RDM001 (Philips) ZHA support

### DIFF
--- a/apps/controllerx/cx_devices/philips.py
+++ b/apps/controllerx/cx_devices/philips.py
@@ -247,6 +247,22 @@ class Philips929003017102LightController(LightController):
             2003: Light.RELEASE,
         }
 
+    def get_zha_actions_mapping(self) -> DefaultActionsMapping:
+        return {
+            # "left_press": Light.TOGGLE,
+            "left_press_release": Light.TOGGLE,
+            "left_hold": Light.HOLD_BRIGHTNESS_TOGGLE,
+            "left_hold_release": Light.RELEASE,
+            # "right_press": Light.TOGGLE,
+            "right_press_release": Light.TOGGLE,
+            "right_hold": Light.HOLD_BRIGHTNESS_TOGGLE,
+            "right_hold_release": Light.RELEASE,
+        }
+
+    def get_zha_action(self, data: EventData) -> str:
+        command: str = data["command"]
+        return command
+
 
 class Philips929003017102Z2MLightController(Z2MLightController):
     def get_z2m_actions_mapping(self) -> DefaultActionsMapping:


### PR DESCRIPTION
Hi!

I noticed that the Hue Wall Switch Module only had deconz and z2m support, so this is a stab at adding ZHA support.

I am very much a beginner when it comes to HA and ControllerX, I am not even sure how to test this 🙈 .

I did examine the `zha_event`s that were sent when clicking on my Wall Switch Module, and the event names matched up perfectly with the event names that were already defined in `get_z2m_actions_mapping`. Therefore I think it could be correct to copy-paste that one.

I'm happy for any guidance to take this over the finish line :)