### PR TITLE
Support ZHA for Sengled E1EG7FLightController

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -10,11 +10,9 @@ _This minor change does not contain any breaking changes._
 ## :pencil2: Features
 -->
 
-<!--
 ## :video_game: New devices
 
-- [XYZ](https://BASE_URL/controllerx/controllers/XYZ) - add device with Z2M support. [ #123 ]
--->
+- [E1EG7F](https://BASE_URL/controllerx/controllers/E1EG7F) - add ZHA support. [ #879 ] @sreknob
 
 <!--
 ## :hammer: Fixes

--- a/apps/controllerx/cx_devices/sengled.py
+++ b/apps/controllerx/cx_devices/sengled.py
@@ -31,6 +31,7 @@ class E1EG7FLightController(LightController):
             "off_double": Light.ON_MIN_COLOR_TEMP,
         }
 
+
 class E1EG7FZ2MLightController(Z2MLightController):
     def get_z2m_actions_mapping(self) -> DefaultActionsMapping:
         return {

--- a/apps/controllerx/cx_devices/sengled.py
+++ b/apps/controllerx/cx_devices/sengled.py
@@ -17,6 +17,19 @@ class E1EG7FLightController(LightController):
             "off_double": Light.ON_MIN_COLOR_TEMP,
         }
 
+    def get_zha_actions_mapping(self) -> DefaultActionsMapping:
+        return {
+            "on": Light.ON,
+            "on_long": Light.CLICK_COLOR_UP,
+            "on_double": Light.ON_FULL_COLOR_TEMP,
+            "step_0_1_0": Light.CLICK_BRIGHTNESS_UP,
+            "step_0_2_0": Light.ON_FULL_BRIGHTNESS,
+            "step_1_1_0": Light.CLICK_BRIGHTNESS_DOWN,
+            "step_1_2_0": Light.ON_MIN_BRIGHTNESS,
+            "off": Light.OFF,
+            "off_long": Light.CLICK_COLOR_DOWN,
+            "off_double": Light.ON_MIN_COLOR_TEMP,
+        }
 
 class E1EG7FZ2MLightController(Z2MLightController):
     def get_z2m_actions_mapping(self) -> DefaultActionsMapping:


### PR DESCRIPTION
Adds in ZHA support for the Sengled E1E G7F ZigBee remote controller using same default actions as Z2M.

Tested locally and works as expected.

Looks like your docs are now completely dynamic (cool!) so let me know if you need any other PRs for this.

Thanks!