### PR TITLE
Fix TS0043 Cover Controller

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -16,9 +16,9 @@ _This minor change does not contain any breaking changes._
 - [XYZ](https://BASE_URL/controllerx/controllers/XYZ) - add device with Z2M support. [ #123 ]
 -->
 
-<!--
 ## :hammer: Fixes
--->
+
+- [TS0043](https://BASE_URL/controllerx/controllers/TS0043) - fix cover mapping [ #1082 ] @ChristopheBraud
 
 <!--
 ## :scroll: Docs

--- a/apps/controllerx/cx_devices/tuya.py
+++ b/apps/controllerx/cx_devices/tuya.py
@@ -78,9 +78,9 @@ class TS0043LightController(LightController):
 class TS0043CoverController(CoverController):
     def get_z2m_actions_mapping(self) -> DefaultActionsMapping:
         return {
-            "1_single": Cover.TOGGLE_OPEN,
+            "1_single": Cover.OPEN,
             "2_single": Cover.STOP,
-            "3_single": Cover.TOGGLE_CLOSE,
+            "3_single": Cover.CLOSE,
         }
 
 class TuYaERS10TZBVKAALightController(LightController):

--- a/apps/controllerx/cx_devices/tuya.py
+++ b/apps/controllerx/cx_devices/tuya.py
@@ -83,6 +83,7 @@ class TS0043CoverController(CoverController):
             "3_single": Cover.CLOSE,
         }
 
+
 class TuYaERS10TZBVKAALightController(LightController):
     def get_z2m_actions_mapping(self) -> DefaultActionsMapping:
         return {

--- a/apps/controllerx/cx_devices/tuya.py
+++ b/apps/controllerx/cx_devices/tuya.py
@@ -83,7 +83,6 @@ class TS0043CoverController(CoverController):
             "3_single": Cover.TOGGLE_CLOSE,
         }
 
-
 class TuYaERS10TZBVKAALightController(LightController):
     def get_z2m_actions_mapping(self) -> DefaultActionsMapping:
         return {


### PR DESCRIPTION
I forgot a commit on my last PR  #1076 (sorry)

As I said before, I use Open and Close action rather than toggle actions as there is already a stop button on the controller.
There's also a weird behavior with toggle actions where toggle_open stop a closing action rather than opening the cover.

I suppose this is correct for a two buttons controller, but not for a three buttons one.

---
Also there is a small mistake in the release notes of [v4.28.0](https://github.com/xaviml/controllerx/releases/tag/v4.28.0): 
🎮 New devices

    [TS0042](https://xaviml.github.io/controllerx/controllers/TS0042) - add device with ZHA support. [ https://github.com/xaviml/controllerx/pull/1065 ] @Strauman
    [TS0043](https://xaviml.github.io/controllerx/controllers/TS0043) - add ZHA support. [ https://github.com/xaviml/controllerx/pull/1066 ] @Strauman
    [TS0043](https://xaviml.github.io/controllerx/controllers/TS0043) - add cover controll with ZHA support. [ https://github.com/xaviml/controllerx/pull/1076 ] @ChristopheBraud

Last line should be Z2M, not ZHA. I don't know if you can fix it or not
