### PR TITLE
E2123 Media Player Controller: toggle play/pause

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -18,6 +18,7 @@
 ## :hammer: Fixes
 
 - [TS0043](https://BASE_URL/controllerx/controllers/TS0043) - fix cover mapping [ #1082 ] @ChristopheBraud
+- [E2123](https://BASE_URL/controllerx/controllers/E2123) - fix media player mapping [ #1102 ] @sevorl
 
 ## :scroll: Docs
 

--- a/apps/controllerx/cx_devices/ikea.py
+++ b/apps/controllerx/cx_devices/ikea.py
@@ -772,8 +772,8 @@ class E2123MediaPlayerController(MediaPlayerController):
 
     def get_z2m_actions_mapping(self) -> DefaultActionsMapping:
         return {
-            "toggle": MediaPlayer.PLAY,  # click Play button
-            "play_pause": MediaPlayer.PLAY,  # click Play button
+            "toggle": MediaPlayer.PLAY_PAUSE,  # click Play button
+            "play_pause": MediaPlayer.PLAY_PAUSE,  # click Play button
             "track_next": MediaPlayer.NEXT_TRACK,  # click Next Track
             "track_previous": MediaPlayer.PREVIOUS_TRACK,  # click Previous Track
             "volume_up": MediaPlayer.CLICK_VOLUME_UP,  # click + (Volume up)


### PR DESCRIPTION
The Ikea E2123 Medie Player controller has a toggle button to play/pause. However, the mapping was set to "PLAY" instead of "PLAY_PAUSE", so it was not possible to pause the media player.

Pausing was only possible with a custom
  merge_mapping: 
    toggle: play_pause
  
(Note: the same button is named "toggle" or "play_pause" depending on the firmware of the device)