### PR TITLE
Log on debug level if action not in payload

### DIFF
--- a/apps/controllerx/cx_core/integration/z2m.py
+++ b/apps/controllerx/cx_core/integration/z2m.py
@@ -58,8 +58,8 @@ class Z2MIntegration(Integration):
         payload = json.loads(data["payload"])
         if action_key not in payload:
             self.controller.log(
-                f"⚠️ There is no `{action_key}` in the MQTT topic payload",
-                level="WARNING",
+                f"There is no `{action_key}` in the MQTT topic payload",
+                level="DEBUG",
                 ascii_encode=False,
             )
             return


### PR DESCRIPTION
I would like to propose setting the log level to DEBUG if action is not present in the MQTT payload, since this creates a lot of noise during firmware upgrades:

<img width="400" alt="image" src="https://github.com/user-attachments/assets/9430d22d-e2e3-466c-a033-c6de2fe8afa0" />

Also, isn’t it legitimate to receive messages with a payload that doesn’t contain an action?