### PR TITLE
Fixed color temp commands

### DIFF
--- a/apps/controllerx/cx_core/type/light_controller.py
+++ b/apps/controllerx/cx_core/type/light_controller.py
@@ -452,7 +452,9 @@ class LightController(TypeController[LightEntity], ReleaseHoldController):
 
     async def _on(self, **attributes: Any) -> None:
         if "color_temp" in attributes:
-            attributes["color_temp_kelvin"] = round(1000000 / attributes.pop("color_temp"))
+            attributes["color_temp_kelvin"] = round(
+                1000000 / attributes.pop("color_temp")
+            )
         await self.call_light_service("light/turn_on", **attributes)
 
     @action

--- a/apps/controllerx/cx_core/type/light_controller.py
+++ b/apps/controllerx/cx_core/type/light_controller.py
@@ -451,6 +451,8 @@ class LightController(TypeController[LightEntity], ReleaseHoldController):
         await self.call_service(service, entity_id=self.entity.name, **attributes)
 
     async def _on(self, **attributes: Any) -> None:
+        if "color_temp" in attributes:
+            attributes["color_temp_kelvin"] = round(1000000 / attributes.pop("color_temp"))
         await self.call_light_service("light/turn_on", **attributes)
 
     @action

--- a/tests/integ_tests/example_config/example_config_colortemp_from_xycolor_test.yaml
+++ b/tests/integ_tests/example_config/example_config_colortemp_from_xycolor_test.yaml
@@ -9,5 +9,5 @@ expected_calls:
   - service: light/turn_on
     data:
       entity_id: light.livingroom
-      color_temp: 291
+      color_temp_kelvin: 3436
       transition: 0.3

--- a/tests/integ_tests/example_config/example_config_toggle_colortemp_test.yaml
+++ b/tests/integ_tests/example_config/example_config_toggle_colortemp_test.yaml
@@ -10,5 +10,5 @@ expected_calls:
   - service: light/turn_on
     data:
       entity_id: light.livingroom
-      color_temp: 370
+      color_temp_kelvin: 2703
       brightness: 255

--- a/tests/integ_tests/muller_licht_z2m/colot_temp_from_controller_test.yaml
+++ b/tests/integ_tests/muller_licht_z2m/colot_temp_from_controller_test.yaml
@@ -6,4 +6,4 @@ expected_calls:
   - service: light/turn_on
     data:
       entity_id: light.my_light
-      color_temp: 200
+      color_temp_kelvin: 5000

--- a/tests/integ_tests/predefined_action_attrs/sync_test.yaml
+++ b/tests/integ_tests/predefined_action_attrs/sync_test.yaml
@@ -6,5 +6,5 @@ expected_calls:
   - service: light/turn_on
     data:
       entity_id: light.bedroom
-      color_temp: 200
+      color_temp_kelvin: 5000
       brightness: 34

--- a/tests/integ_tests/predefined_action_on_min_max/on_min_max_color_temp_when_colortemp_200_test.yaml
+++ b/tests/integ_tests/predefined_action_on_min_max/on_min_max_color_temp_when_colortemp_200_test.yaml
@@ -6,4 +6,4 @@ expected_calls:
   - service: light/turn_on
     data:
       entity_id: light.bedroom
-      color_temp: 153
+      color_temp_kelvin: 6536

--- a/tests/integ_tests/predefined_action_on_min_max/on_min_max_color_temp_when_colortemp_max_test.yaml
+++ b/tests/integ_tests/predefined_action_on_min_max/on_min_max_color_temp_when_colortemp_max_test.yaml
@@ -6,4 +6,4 @@ expected_calls:
   - service: light/turn_on
     data:
       entity_id: light.bedroom
-      color_temp: 153
+      color_temp_kelvin: 6536

--- a/tests/integ_tests/predefined_action_on_min_max/on_min_max_color_temp_when_colortemp_min_and_off_test.yaml
+++ b/tests/integ_tests/predefined_action_on_min_max/on_min_max_color_temp_when_colortemp_min_and_off_test.yaml
@@ -6,4 +6,4 @@ expected_calls:
   - service: light/turn_on
     data:
       entity_id: light.bedroom
-      color_temp: 153
+      color_temp_kelvin: 6536

--- a/tests/integ_tests/predefined_action_on_min_max/on_min_max_color_temp_when_colortemp_min_test.yaml
+++ b/tests/integ_tests/predefined_action_on_min_max/on_min_max_color_temp_when_colortemp_min_test.yaml
@@ -6,4 +6,4 @@ expected_calls:
   - service: light/turn_on
     data:
       entity_id: light.bedroom
-      color_temp: 500
+      color_temp_kelvin: 2000

--- a/tests/integ_tests/predefined_action_on_min_max/on_min_max_color_temp_when_off_test.yaml
+++ b/tests/integ_tests/predefined_action_on_min_max/on_min_max_color_temp_when_off_test.yaml
@@ -4,4 +4,4 @@ expected_calls:
   - service: light/turn_on
     data:
       entity_id: light.bedroom
-      color_temp: 153
+      color_temp_kelvin: 6536

--- a/tests/integ_tests/steppers/click_loop_test.yaml
+++ b/tests/integ_tests/steppers/click_loop_test.yaml
@@ -7,4 +7,4 @@ expected_calls:
     data:
       entity_id: light.livingroom
       transition: 0.3
-      color_temp: 177
+      color_temp_kelvin: 5650

--- a/tests/integ_tests/steppers/hold_loop_test.yaml
+++ b/tests/integ_tests/steppers/hold_loop_test.yaml
@@ -7,9 +7,9 @@ expected_calls:
     data:
       entity_id: light.livingroom
       transition: 0.35
-      color_temp: 472
+      color_temp_kelvin: 2119
   - service: light/turn_on
     data:
       entity_id: light.livingroom
       transition: 0.35
-      color_temp: 437
+      color_temp_kelvin: 2288

--- a/tests/integ_tests/supported_features_field/arrow_hold_test.yaml
+++ b/tests/integ_tests/supported_features_field/arrow_hold_test.yaml
@@ -11,9 +11,9 @@ expected_calls:
     data:
       entity_id: light.bedroom
       transition: 0.35
-      color_temp: 234
+      color_temp_kelvin: 4274
   - service: light/turn_on
     data:
       entity_id: light.bedroom
       transition: 0.35
-      color_temp: 268
+      color_temp_kelvin: 3731

--- a/tests/integ_tests/tuya_knob_zha/color_temp_from_controller_down_test.yaml
+++ b/tests/integ_tests/tuya_knob_zha/color_temp_from_controller_down_test.yaml
@@ -13,5 +13,5 @@ expected_calls:
   - service: light/turn_on
     data:
       entity_id: light.my_light
-      color_temp: 163
+      color_temp_kelvin: 6135
       transition: 3

--- a/tests/integ_tests/tuya_knob_zha/color_temp_from_controller_up_test.yaml
+++ b/tests/integ_tests/tuya_knob_zha/color_temp_from_controller_up_test.yaml
@@ -13,5 +13,5 @@ expected_calls:
   - service: light/turn_on
     data:
       entity_id: light.my_light
-      color_temp: 213
+      color_temp_kelvin: 4695
       transition: 1

--- a/tests/integ_tests/zb5122/move_to_color_test.yaml
+++ b/tests/integ_tests/zb5122/move_to_color_test.yaml
@@ -6,4 +6,4 @@ expected_calls:
   - service: light/turn_on
     data:
       entity_id: light.my_light
-      color_temp: 230
+      color_temp_kelvin: 4348

--- a/tests/unit_tests/cx_core/type/light_controller_test.py
+++ b/tests/unit_tests/cx_core/type/light_controller_test.py
@@ -527,7 +527,7 @@ async def test_on_min(sut: LightController, mocker: MockerFixture) -> None:
 @pytest.mark.parametrize(
     "max_brightness, color_attribute, expected_attributes",
     [
-        (255, "color_temp", {"brightness": 255, "color_temp": 370}),
+        (255, "color_temp", {"brightness": 255, "color_temp_kelvin": round(1000000 / 370)}),
         (255, "xy_color", {"brightness": 255, "xy_color": [0.323, 0.329]}),
         (120, "error", {"brightness": 120}),
     ],

--- a/tests/unit_tests/cx_core/type/light_controller_test.py
+++ b/tests/unit_tests/cx_core/type/light_controller_test.py
@@ -527,7 +527,11 @@ async def test_on_min(sut: LightController, mocker: MockerFixture) -> None:
 @pytest.mark.parametrize(
     "max_brightness, color_attribute, expected_attributes",
     [
-        (255, "color_temp", {"brightness": 255, "color_temp_kelvin": round(1000000 / 370)}),
+        (
+            255,
+            "color_temp",
+            {"brightness": 255, "color_temp_kelvin": round(1000000 / 370)},
+        ),
         (255, "xy_color", {"brightness": 255, "xy_color": [0.323, 0.329]}),
         (120, "error", {"brightness": 120}),
     ],


### PR DESCRIPTION
Replaced now deprecated 'color_temp' (mireds) HA attribute with 'color_temp_kelvin'.
This fixed color temp commands failing with errors like this:
```
appdaemon  | 2026-05-12 01:51:02.097131 WARNING HASS: Error with websocket result: invalid_format: extra keys not allowed @ data['color_temp']: request={'type': 'call_service', 'domain': 'light', 'service': 'turn_on', 'service_data': {'color_temp': 337}, 'target': {'entity_id': 'light.my_light'}, 'id': 7}
```
This is a bit of a bandaid fix, I just know it worked for me and figured I should share.
Fixes https://github.com/xaviml/controllerx/issues/1349